### PR TITLE
Add footprint association support

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -10,6 +10,51 @@ module.exports = _.defaultsDeep({
   },
   api: {
     models: {
+      Page: class Page extends Model {
+        static config() {
+          return {
+            options: {
+              classMethods: {
+                associate: (models) => {
+                  models.Page.belongsTo(models.User, { as: 'Owner' })
+                }
+              }
+            }
+          }
+        }
+
+        static schema(app, Sequelize) {
+          return {
+            name: { type: Sequelize.STRING, allowNull: false}
+          }
+        }
+      },
+      Project: class Project extends Model {
+        static config() {
+          return {
+            options: {
+              classMethods: {
+                associate: (models) => {
+                  models.Project.belongsToMany(models.User, { through: models.UserProject })
+                  models.Project.hasOne(models.Page)
+                }
+              }
+            }
+          }
+        }
+        static schema(app, Sequelize) {
+          return {
+            name: Sequelize.STRING
+          }
+        }
+      },
+      UserProject: class UserProject extends Model {
+        static schema(app, Sequelize) {
+          return {
+            status: Sequelize.STRING
+          }
+        }
+      },
       User: class User extends Model {
         static config() {
           return {


### PR DESCRIPTION
Resolves #2

- [x] createAssociation - foreignKeyField (e.g. hasMany)
- [x] findAssociation - foreignKeyField (e.g. hasMany)
- [x] updateAssociation - foreignKeyField (e.g. hasMany)
- [x] destroyAssociation - foreignKeyField (e.g. hasMany)
- [x] createAssociation - !foreignKeyField && !through (source key, e.g. belongsTo)
- [x] findAssociation - !foreignKeyField && !through (source key, e.g. belongsTo)
- [x] updateAssociation - !foreignKeyField && !through (source key, e.g. belongsTo)
- [x] destroyAssociation - !foreignKeyField && !through (source key, e.g. belongsTo)
- N/A createAssociation - through (e.g. belongsToMany) - API does not allow for choosing addition values of join table, should be created with two creates - one for join table, the other for the associated object
- [x] findAssociation - through (e.g. belongsToMany)
- [x] updateAssociation - through (e.g. belongsToMany)
- [x] destroyAssociation - through (e.g. belongsToMany)