### PR TITLE
Throw SequelizeUniqueConstraintError: E_VALIDATION

### DIFF
--- a/api/services/FootprintService.js
+++ b/api/services/FootprintService.js
@@ -5,7 +5,7 @@ const Service = require('trails-service')
 const ModelError = require('../../lib').ModelError
 
 const manageError = err => {
-  if (err.name === 'SequelizeValidationError') {
+  if (err.name === 'SequelizeValidationError' || err.name === 'SequelizeUniqueConstraintError') {
     return Promise.reject(new ModelError('E_VALIDATION', err.message, err.errors))
   }
   return Promise.reject(err)


### PR DESCRIPTION
When your insertion throws a `SequelizeUniqueConstraintError`, trails should throw an `E_VALIDATION` error that reachs the api's JSON response, as it does (currently only with Express) when there is a `SequelizeValidationError`.

At least on hapi, current behaivor is to display an `500, internal server error` on the api's JSON response.
