### PR TITLE
Use Sequelize v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "joi": "^8.4.2",
     "lodash": "^4.13.1",
-    "sequelize": "^3.23.6",
+    "sequelize": "^4.0.0",
     "trailpack-datastore": "^1.0.2",
     "trails-service": "^1.0.0-beta-2"
   },


### PR DESCRIPTION
> Starting from 4.0.0 Sequelize will only support Node v4 and above to use ES6 features.
